### PR TITLE
fix(sce): use existing backend contract

### DIFF
--- a/src/converter/backend.js
+++ b/src/converter/backend.js
@@ -1,5 +1,3 @@
-import { normalizeApiBaseUrl } from '../views/home/index.js';
-
 export const BACKEND_TYPES = Object.freeze({
   AUTO: 'auto',
   SCE: 'sce',
@@ -50,106 +48,6 @@ export function parseBackendIdentity(value) {
   };
 }
 
-function stringArray(value) {
-  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string' || !item)) {
-    return null;
-  }
-  return [...value];
-}
-
-export function validateSceCapabilities(value) {
-  if (!value || typeof value !== 'object' || value.schema_version !== 1) {
-    throw new TypeError('SCE 能力接口版本不受支持');
-  }
-  if (value.backend?.family !== 'SubConverter-Extended') {
-    throw new TypeError('SCE 能力接口返回了不匹配的后端标识');
-  }
-  if (!Array.isArray(value.targets) || value.targets.length === 0) {
-    throw new TypeError('SCE 能力接口未返回目标客户端');
-  }
-
-  const targets = value.targets.map((item) => {
-    if (!item || typeof item.name !== 'string' || !/^[a-z0-9]+$/.test(item.name)) {
-      throw new TypeError('SCE 能力接口包含无效目标客户端');
-    }
-    return {
-      name: item.name,
-      parser: typeof item.parser === 'string' ? item.parser : '',
-      remote_mode: typeof item.remote_mode === 'string' ? item.remote_mode : '',
-      simple_subscription: item.simple_subscription === true,
-    };
-  });
-  if (new Set(targets.map((item) => item.name)).size !== targets.length) {
-    throw new TypeError('SCE 能力接口包含重复目标客户端');
-  }
-
-  const parameters = value.query_parameters || {};
-  const recognized = stringArray(parameters.recognized);
-  const ignored = stringArray(parameters.ignored);
-  const internal = stringArray(parameters.internal);
-  if (!recognized || !ignored || !internal) {
-    throw new TypeError('SCE 能力接口参数定义无效');
-  }
-
-  const targetConstraints = {};
-  for (const [name, targetNames] of Object.entries(parameters.target_constraints || {})) {
-    const normalized = stringArray(targetNames);
-    if (!/^[a-z0-9_]+$/.test(name) || !normalized) {
-      throw new TypeError('SCE 能力接口目标约束无效');
-    }
-    targetConstraints[name] = normalized;
-  }
-
-  const sourceModifiers = Array.isArray(value.source_modifiers)
-    ? value.source_modifiers.map((item) => {
-        const modifierTargets = stringArray(item?.targets);
-        if (!item || typeof item.name !== 'string' || !modifierTargets) {
-          throw new TypeError('SCE 能力接口来源参数无效');
-        }
-        return {
-          name: item.name,
-          type: typeof item.type === 'string' ? item.type : 'string',
-          targets: modifierTargets,
-        };
-      })
-    : [];
-
-  return {
-    schema_version: 1,
-    backend: {
-      family: 'SubConverter-Extended',
-      version: String(value.backend.version || ''),
-      revision: String(value.backend.revision || ''),
-    },
-    targets,
-    query_parameters: {
-      recognized,
-      ignored,
-      internal,
-      forced: parameters.forced?.new_name === true ? { new_name: true } : {},
-      target_constraints: targetConstraints,
-    },
-    source_modifiers: sourceModifiers,
-  };
-}
-
-export function assertCapabilitiesMatchIdentity(capabilities, identity) {
-  if (identity?.family !== BACKEND_TYPES.SCE) {
-    throw new TypeError('能力接口无法绑定到非 SCE 后端');
-  }
-  if (identity.version && capabilities.backend.version && identity.version !== capabilities.backend.version) {
-    throw new TypeError('SCE 能力接口版本与 /version 不一致');
-  }
-  if (identity.revision && capabilities.backend.revision) {
-    const left = identity.revision.toLowerCase();
-    const right = capabilities.backend.revision.toLowerCase();
-    if (!left.startsWith(right) && !right.startsWith(left)) {
-      throw new TypeError('SCE 能力接口修订与 /version 不一致');
-    }
-  }
-  return capabilities;
-}
-
 export function resolveBackendType(configuredType, detectedFamily, reachable) {
   const configured = normalizeBackendType(configuredType);
   if (!reachable) {
@@ -159,8 +57,4 @@ export function resolveBackendType(configuredType, detectedFamily, reachable) {
     return BACKEND_TYPES.UNKNOWN;
   }
   return detectedFamily;
-}
-
-export function capabilitiesUrl(api) {
-  return `${normalizeApiBaseUrl(api)}/capabilities`;
 }

--- a/src/converter/profiles.js
+++ b/src/converter/profiles.js
@@ -147,14 +147,11 @@ function expandTarget(name) {
   return [{ value: name, text: TARGET_LABELS[name] || name }];
 }
 
-export function getTargetOptions(backendType, capabilities) {
+export function getTargetOptions(backendType) {
   if (backendType !== BACKEND_TYPES.SCE) {
     return LEGACY_TARGET_OPTIONS;
   }
-  const supported = Array.isArray(capabilities?.targets)
-    ? capabilities.targets.map((item) => item.name)
-    : SCE_TARGET_NAMES;
-  return supported.flatMap(expandTarget);
+  return SCE_TARGET_NAMES.flatMap(expandTarget);
 }
 
 export function baseTarget(target) {
@@ -170,54 +167,42 @@ const SCE_TARGET_CONSTRAINTS = Object.freeze({
   classic: ['clash', 'clashr'],
 });
 
-export function isParameterAvailable(name, backendType, target, capabilities) {
+export function isParameterAvailable(name, backendType, target) {
   if (backendType !== BACKEND_TYPES.SCE) {
     return name !== 'provider_headers';
   }
   if (SCE_UNSUPPORTED.has(name)) {
     return false;
   }
-  const remoteParameters = capabilities?.query_parameters;
-  if (
-    remoteParameters?.ignored?.includes(name) ||
-    remoteParameters?.internal?.includes(name) ||
-    Object.prototype.hasOwnProperty.call(remoteParameters?.forced || {}, name)
-  ) {
-    return false;
-  }
-  if (Array.isArray(remoteParameters?.recognized) && !remoteParameters.recognized.includes(name)) {
-    return false;
-  }
   const targetName = baseTarget(target);
-  const remoteConstraints = capabilities?.query_parameters?.target_constraints?.[name];
-  const constraints = Array.isArray(remoteConstraints) ? remoteConstraints : SCE_TARGET_CONSTRAINTS[name];
+  const constraints = SCE_TARGET_CONSTRAINTS[name];
   return !constraints || constraints.includes(targetName);
 }
 
-export function availableBooleanParameters(backendType, target, capabilities) {
-  return BOOLEAN_PARAMETER_OPTIONS.filter((item) => isParameterAvailable(item.key, backendType, target, capabilities));
+export function availableBooleanParameters(backendType, target) {
+  return BOOLEAN_PARAMETER_OPTIONS.filter((item) => isParameterAvailable(item.key, backendType, target));
 }
 
-export function availableParameterNames(backendType, target, capabilities) {
+export function availableParameterNames(backendType, target) {
   return [...TEXT_PARAMETERS, ...BASE64_PARAMETERS, ...BOOLEAN_PARAMETERS].filter((name) =>
-    isParameterAvailable(name, backendType, target, capabilities),
+    isParameterAvailable(name, backendType, target),
   );
 }
 
-export function countActiveOptions(moreConfig, backendType, target, capabilities) {
-  return availableParameterNames(backendType, target, capabilities).filter((name) => {
+export function countActiveOptions(moreConfig, backendType, target) {
+  return availableParameterNames(backendType, target).filter((name) => {
     const value = moreConfig?.[name];
     return typeof value === 'string' ? value.trim() !== '' : value !== undefined && value !== null;
   }).length;
 }
 
-export function filterMoreConfig(moreConfig, backendType, target, capabilities) {
-  const allowed = new Set(availableParameterNames(backendType, target, capabilities));
+export function filterMoreConfig(moreConfig, backendType, target) {
+  const allowed = new Set(availableParameterNames(backendType, target));
   return Object.fromEntries(Object.entries(moreConfig || {}).filter(([name]) => allowed.has(name)));
 }
 
-export function countSuppressedOptions(moreConfig, backendType, target, capabilities) {
-  const allowed = new Set(availableParameterNames(backendType, target, capabilities));
+export function countSuppressedOptions(moreConfig, backendType, target) {
+  const allowed = new Set(availableParameterNames(backendType, target));
   return Object.entries(moreConfig || {}).filter(([name, value]) => {
     const active = typeof value === 'string' ? value.trim() !== '' : value !== undefined && value !== null;
     return active && !allowed.has(name);

--- a/src/converter/source-modifiers.js
+++ b/src/converter/source-modifiers.js
@@ -56,14 +56,11 @@ export function parseSourceItems(value) {
   return splitSources(value).map(parseSourceItem);
 }
 
-export function modifierAvailable(key, target, capabilities) {
-  const remoteName = key === 'proxyDirect' ? 'proxy_direct' : key;
-  const remote = capabilities?.source_modifiers?.find((item) => item.name === remoteName);
-  const targets = remote?.targets || SOURCE_MODIFIER_TARGETS[key];
-  return targets?.includes(baseTarget(target)) === true;
+export function modifierAvailable(key, target) {
+  return SOURCE_MODIFIER_TARGETS[key]?.includes(baseTarget(target)) === true;
 }
 
-export function validateSourceItems(items, target, capabilities) {
+export function validateSourceItems(items, target) {
   if (!Array.isArray(items) || items.length === 0) {
     throw new TypeError('请先输入至少一条订阅链接或节点');
   }
@@ -73,7 +70,7 @@ export function validateSourceItems(items, target, capabilities) {
       throw new TypeError(`第 ${index + 1} 条来源缺少 URL 或节点`);
     }
     for (const key of ['tag', 'provider', 'interval', 'proxyDirect']) {
-      if (String(item[key] || '').trim() && !modifierAvailable(key, targetName, capabilities)) {
+      if (String(item[key] || '').trim() && !modifierAvailable(key, targetName)) {
         throw new TypeError(`第 ${index + 1} 条来源的${MODIFIER_LABELS[key]}不适用于当前目标客户端`);
       }
     }
@@ -104,7 +101,7 @@ export function serializeSourceItem(item) {
   return [...prefixes, item.url.trim()].join(',');
 }
 
-export function serializeSourceItems(items, target, capabilities) {
-  validateSourceItems(items, target, capabilities);
+export function serializeSourceItems(items, target) {
+  validateSourceItems(items, target);
   return items.map(serializeSourceItem).join('\n');
 }

--- a/src/views/home/SubTable.vue
+++ b/src/views/home/SubTable.vue
@@ -366,15 +366,7 @@ import {
 } from './index.js';
 import showNotification from '@/components/notification';
 import { getRuntimeConfig } from '@/config/runtime.js';
-import {
-  BACKEND_TYPES,
-  assertCapabilitiesMatchIdentity,
-  capabilitiesUrl,
-  normalizeBackendType,
-  parseBackendIdentity,
-  resolveBackendType,
-  validateSceCapabilities,
-} from '@/converter/backend.js';
+import { BACKEND_TYPES, normalizeBackendType, parseBackendIdentity, resolveBackendType } from '@/converter/backend.js';
 import {
   DEFAULT_MORE_CONFIG,
   availableBooleanParameters,
@@ -427,8 +419,6 @@ export default {
         version: '',
         type: BACKEND_TYPES.UNKNOWN,
         configuredType: BACKEND_TYPES.AUTO,
-        capabilities: null,
-        capabilitySource: '',
         warning: '',
       },
       backendProbeController: null,
@@ -449,25 +439,22 @@ export default {
       return this.runtimeConfig.enableShortUrl;
     },
     activeOptionCount() {
-      return countActiveOptions(this.moreConfig, this.backendType, this.target, this.backendCapabilities);
+      return countActiveOptions(this.moreConfig, this.backendType, this.target);
     },
     suppressedOptionCount() {
-      return countSuppressedOptions(this.moreConfig, this.backendType, this.target, this.backendCapabilities);
+      return countSuppressedOptions(this.moreConfig, this.backendType, this.target);
     },
     backendType() {
       return this.backendProbe.type === BACKEND_TYPES.SCE ? BACKEND_TYPES.SCE : BACKEND_TYPES.LEGACY;
-    },
-    backendCapabilities() {
-      return this.backendProbe.capabilities;
     },
     isSce() {
       return this.backendType === BACKEND_TYPES.SCE;
     },
     targetOptions() {
-      return getTargetOptions(this.backendType, this.backendCapabilities);
+      return getTargetOptions(this.backendType);
     },
     availableBooleanParameters() {
-      return availableBooleanParameters(this.backendType, this.target, this.backendCapabilities);
+      return availableBooleanParameters(this.backendType, this.target);
     },
     targetLabel() {
       return this.targetOptions.find((option) => option.value === this.target)?.text || this.target;
@@ -478,8 +465,7 @@ export default {
       }
       if (this.backendProbe.state === 'online') {
         if (this.backendProbe.type === BACKEND_TYPES.SCE) {
-          const source = this.backendProbe.capabilitySource === 'remote' ? '动态能力' : '内置能力';
-          return `在线 · SCE · ${this.backendProbe.version} · ${source}`;
+          return `在线 · SCE · ${this.backendProbe.version} · 已启用专用适配`;
         }
         if (this.backendProbe.type === BACKEND_TYPES.LEGACY) {
           return `在线 · 传统后端 · ${this.backendProbe.version}`;
@@ -566,8 +552,6 @@ export default {
         version: '',
         type: BACKEND_TYPES.UNKNOWN,
         configuredType: BACKEND_TYPES.AUTO,
-        capabilities: null,
-        capabilitySource: '',
         warning: '',
       });
     },
@@ -627,27 +611,9 @@ export default {
         }
         const identity = parseBackendIdentity(body);
         const resolvedType = resolveBackendType(configuredType, identity.family, true);
-        let capabilities = null;
-        let capabilitySource = '';
         let warning = '';
         if (resolvedType === BACKEND_TYPES.UNKNOWN && configuredType !== BACKEND_TYPES.AUTO) {
           warning = `站点把后端配置为 ${configuredType === BACKEND_TYPES.SCE ? 'SCE' : '传统模式'}，但 /version 返回了不同类型；已暂停专用能力。`;
-        } else if (resolvedType === BACKEND_TYPES.SCE) {
-          try {
-            const capabilityResponse = await fetch(capabilitiesUrl(normalizedApi), { signal: controller.signal });
-            if (!capabilityResponse.ok) {
-              throw new Error(`HTTP ${capabilityResponse.status}`);
-            }
-            capabilities = assertCapabilitiesMatchIdentity(
-              validateSceCapabilities(await capabilityResponse.json()),
-              identity,
-            );
-            capabilitySource = 'remote';
-          } catch (error) {
-            if (requestId !== this.backendProbeRequestId) return;
-            capabilitySource = 'bundled';
-            warning = `SCE 能力接口不可用，已使用当前前端内置能力（${error.name === 'AbortError' ? '请求超时' : '无法读取 /capabilities'}）。`;
-          }
         }
         if (requestId !== this.backendProbeRequestId) return;
         this.setBackendProbe({
@@ -655,8 +621,6 @@ export default {
           version: body,
           type: resolvedType,
           configuredType,
-          capabilities,
-          capabilitySource,
           warning,
         });
       } catch {
@@ -669,8 +633,6 @@ export default {
           version: '',
           type: fallbackType,
           configuredType,
-          capabilities: null,
-          capabilitySource: fallbackType === BACKEND_TYPES.SCE ? 'bundled' : '',
           warning:
             fallbackType === BACKEND_TYPES.UNKNOWN
               ? ''
@@ -704,10 +666,10 @@ export default {
       }
     },
     isParameterAvailable(name) {
-      return isParameterAvailable(name, this.backendType, this.target, this.backendCapabilities);
+      return isParameterAvailable(name, this.backendType, this.target);
     },
     sourceModifierAvailable(name) {
-      return modifierAvailable(name, this.target, this.backendCapabilities);
+      return modifierAvailable(name, this.target);
     },
     handleUrlsInput() {
       if (this.isShowSourceEditor) {
@@ -736,7 +698,7 @@ export default {
     },
     applySourceItems() {
       try {
-        this.urls = serializeSceSourceItems(this.sourceItems, this.target, this.backendCapabilities);
+        this.urls = serializeSceSourceItems(this.sourceItems, this.target);
         this.sceSourceModifiersApplied = this.sourceItems.some((item) =>
           ['tag', 'provider', 'interval', 'proxyDirect'].some((key) => String(item[key] || '').trim()),
         );
@@ -787,7 +749,7 @@ export default {
       this.result = { subUrl: '', shortUrl: '' };
       if (this.isSce && this.isShowSourceEditor) {
         try {
-          this.urls = serializeSceSourceItems(this.sourceItems, this.target, this.backendCapabilities);
+          this.urls = serializeSceSourceItems(this.sourceItems, this.target);
           this.sceSourceModifiersApplied = this.sourceItems.some((item) =>
             ['tag', 'provider', 'interval', 'proxyDirect'].some((key) => String(item[key] || '').trim()),
           );
@@ -806,7 +768,7 @@ export default {
       }
       if (this.isSce) {
         try {
-          validateSourceItems(parseSourceItems(this.urls), this.target, this.backendCapabilities);
+          validateSourceItems(parseSourceItems(this.urls), this.target);
         } catch (error) {
           this.setFormMessage(error.message, 'urls');
           return false;
@@ -836,7 +798,6 @@ export default {
           remoteConfig: this.remoteConfig,
           moreConfig: this.moreConfig,
           backendType: this.backendType,
-          capabilities: this.backendCapabilities,
         });
       } catch (error) {
         this.setFormMessage(error.message, 'urls');

--- a/src/views/home/index.js
+++ b/src/views/home/index.js
@@ -64,19 +64,11 @@ export function normalizeRemoteConfigUrl(value) {
   return url.href;
 }
 
-export function countActiveOptions(moreConfig = {}, backendType = 'legacy', target = 'clash', capabilities) {
-  return countProfileOptions(moreConfig, backendType, target, capabilities);
+export function countActiveOptions(moreConfig = {}, backendType = 'legacy', target = 'clash') {
+  return countProfileOptions(moreConfig, backendType, target);
 }
 
-export function getSubLink({
-  urls,
-  api,
-  target,
-  remoteConfig = '',
-  moreConfig = {},
-  backendType = 'legacy',
-  capabilities,
-}) {
+export function getSubLink({ urls, api, target, remoteConfig = '', moreConfig = {}, backendType = 'legacy' }) {
   const normalizedApi = normalizeApiBaseUrl(api);
   const normalizedSources = urls
     .split(/\r?\n|\|/)
@@ -102,7 +94,7 @@ export function getSubLink({
     params.set('config', normalizedRemoteConfig);
   }
 
-  const effectiveConfig = filterMoreConfig(moreConfig, backendType, target, capabilities);
+  const effectiveConfig = filterMoreConfig(moreConfig, backendType, target);
   if (backendType === 'sce' && effectiveConfig.script === 'true' && effectiveConfig.expand === 'true') {
     throw new TypeError('Clash Script 与内联展开规则集不能同时开启');
   }

--- a/test/backend-identity.test.js
+++ b/test/backend-identity.test.js
@@ -1,31 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import {
-  BACKEND_TYPES,
-  assertCapabilitiesMatchIdentity,
-  parseBackendIdentity,
-  resolveBackendType,
-  validateSceCapabilities,
-} from '../src/converter/backend.js';
-
-function capabilitiesFixture() {
-  return {
-    schema_version: 1,
-    backend: { family: 'SubConverter-Extended', version: 'v1.9.2', revision: '483a9e7' },
-    targets: [
-      { name: 'auto', parser: 'user-agent', remote_mode: 'auto', simple_subscription: false },
-      { name: 'clash', parser: 'mihomo', remote_mode: 'clash-proxy-provider', simple_subscription: false },
-    ],
-    query_parameters: {
-      recognized: ['target', 'url', 'new_name'],
-      ignored: ['groups'],
-      internal: ['upload'],
-      forced: { new_name: true },
-      target_constraints: { provider_proxy_direct: ['clash'] },
-    },
-    source_modifiers: [{ name: 'tag', type: 'string', targets: ['clash'] }],
-  };
-}
+import { BACKEND_TYPES, parseBackendIdentity, resolveBackendType } from '../src/converter/backend.js';
 
 test('识别 SCE 正式版、开发版和传统后端版本', () => {
   assert.deepEqual(parseBackendIdentity('SubConverter-Extended v1.9.2-483a9e7 backend'), {
@@ -46,27 +21,4 @@ test('后端配置与在线身份冲突时进入未知安全模式', () => {
   assert.equal(resolveBackendType('sce', BACKEND_TYPES.LEGACY, true), BACKEND_TYPES.UNKNOWN);
   assert.equal(resolveBackendType('sce', BACKEND_TYPES.UNKNOWN, false), BACKEND_TYPES.SCE);
   assert.equal(resolveBackendType('auto', BACKEND_TYPES.UNKNOWN, false), BACKEND_TYPES.UNKNOWN);
-});
-
-test('SCE 能力接口经过严格规范化并拒绝重复目标', () => {
-  const normalized = validateSceCapabilities(capabilitiesFixture());
-  assert.deepEqual(
-    normalized.targets.map((item) => item.name),
-    ['auto', 'clash'],
-  );
-  assert.deepEqual(normalized.query_parameters.forced, { new_name: true });
-
-  const duplicate = capabilitiesFixture();
-  duplicate.targets.push(duplicate.targets[1]);
-  assert.throws(() => validateSceCapabilities(duplicate), /重复目标/);
-
-  assert.equal(
-    assertCapabilitiesMatchIdentity(normalized, parseBackendIdentity('SubConverter-Extended v1.9.2-483a9e7 backend')),
-    normalized,
-  );
-  assert.throws(
-    () =>
-      assertCapabilitiesMatchIdentity(normalized, parseBackendIdentity('SubConverter-Extended v1.9.1-702ba49 backend')),
-    /版本与 \/version 不一致/,
-  );
 });


### PR DESCRIPTION
## Summary

- remove the optional `/capabilities` request and all capability-schema assumptions
- keep SCE adaptation entirely inside SubWeb, based on the existing branded `/version` response
- retain the complete current SCE target, parameter, source-modifier, and diagnostics profiles in SubWeb
- remove the failed endpoint request and its browser console noise

## Validation

- `npm run check`: formatting, ESLint, 28 Node.js tests, Vite production build, Pages Functions bundle
- SCE and traditional version parsing remain covered
- no SubConverter-Extended source, branch, release, image, or runtime change is required