### PR TITLE
refactor(terminology): use full SubConverter-Extended name

### DIFF
--- a/DEPLOY_CLOUDFLARE.md
+++ b/DEPLOY_CLOUDFLARE.md
@@ -1,6 +1,6 @@
 # Cloudflare Pages 部署指南
 
-SubWeb 以 Cloudflare Pages 为主要部署平台。Pages 提供静态前端和运行时配置接口；订阅转换仍由浏览器直接请求所选的 SubConverter 或 SubConverter-Extended（SCE）后端。
+SubWeb 以 Cloudflare Pages 为主要部署平台。Pages 提供静态前端和运行时配置接口；订阅转换仍由浏览器直接请求所选的 SubConverter 或 SubConverter-Extended 后端。
 
 ## 部署边界
 
@@ -10,7 +10,7 @@ SubWeb 以 Cloudflare Pages 为主要部署平台。Pages 提供静态前端和�
 - 短链接功能会把完整转换链接发送到单独配置的短链接服务，默认关闭。
 - Docker 部署仍受支持，但不是本指南的主要部署方式。
 
-因此，部署 SubWeb 之前仍需准备可公开访问的转换后端。SCE 和传统后端可以同时配置。
+因此，部署 SubWeb 之前仍需准备可公开访问的转换后端。SubConverter-Extended 和传统后端可以同时配置。
 
 ## 连接 Git 仓库
 
@@ -54,7 +54,7 @@ Pages 通过 HTTPS 提供页面，因此 `API_URL`、`API_BACKENDS` 中的后端
   {
     "name": "SubConverter-Extended 增强型后端",
     "url": "https://api.example.com",
-    "type": "sce"
+    "type": "subconverter-extended"
   },
   {
     "name": "subconverter 传统型后端",
@@ -66,13 +66,13 @@ Pages 通过 HTTPS 提供页面，因此 `API_URL`、`API_BACKENDS` 中的后端
 
 `type` 支持以下值：
 
-| 值       | 行为                                                    |
-| -------- | ------------------------------------------------------- |
-| `auto`   | 根据 `/version` 自动判断；省略 `type` 时使用此值        |
-| `sce`    | 探测失败时使用内置 SCE 能力；探测结果冲突时暂停专用能力 |
-| `legacy` | 使用传统后端界面和参数                                  |
+| 值                      | 行为                                                                      |
+| ----------------------- | ------------------------------------------------------------------------- |
+| `auto`                  | 根据 `/version` 自动判断；省略 `type` 时使用此值                          |
+| `subconverter-extended` | 探测失败时使用内置 SubConverter-Extended 能力；探测结果冲突时暂停专用能力 |
+| `legacy`                | 使用传统后端界面和参数                                                    |
 
-公开部署已知后端时，建议显式配置 `sce` 或 `legacy`。用户手工输入的后端使用自动判断。
+公开部署已知后端时，建议显式配置 `subconverter-extended` 或 `legacy`。用户手工输入的后端使用自动判断。
 
 ### 远程配置和菜单
 
@@ -112,8 +112,8 @@ Pages 可以为同仓库分支和 Pull Request 创建独立预览部署。预览
 
 1. `/version.json` 中的 `revision` 等于预览部署提交。
 2. `/conf/config.js` 返回预期的后端和 `type`。
-3. SCE 与传统后端切换后，目标客户端列表正确变化。
-4. SCE 专用参数不会进入传统后端链接。
+3. SubConverter-Extended 与传统后端切换后，目标客户端列表正确变化。
+4. SubConverter-Extended 专用参数不会进入传统后端链接。
 5. 浏览器控制台没有新的脚本、CSP 或运行时错误。
 
 ## 自定义域名
@@ -135,7 +135,7 @@ Pages 可以为同仓库分支和 Pull Request 创建独立预览部署。预览
 ## 隐私和安全
 
 - 转换链接可能包含订阅凭据。不要把链接、诊断 JSON 或浏览器日志公开粘贴到 Issue。
-- SCE 诊断会立即把当前来源发送到所选后端，因此前端会在请求前确认。
+- SubConverter-Extended 诊断会立即把当前来源发送到所选后端，因此前端会在请求前确认。
 - Base64 是编码，不是加密。
 - `provider_headers` 只填写 Header 名称。SubWeb 不收集或保存 Header 值。
 - 短链接服务会收到完整转换链接。只在信任该服务时启用。
@@ -148,7 +148,7 @@ Pages 可以为同仓库分支和 Pull Request 创建独立预览部署。预览
 1. 在 Pages 项目的 **Deployments** 中选择上一个成功的生产部署。
 2. 执行 **Rollback to this deployment**。
 3. 验证 `/version.json` 已恢复到预期提交。
-4. 验证 `/conf/config.js`、SCE 模式和传统模式。
+4. 验证 `/conf/config.js`、SubConverter-Extended 模式和传统模式。
 
 预览部署不能作为生产回滚目标。回滚完成前，不要删除出现问题的部署和构建日志。
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ SubWeb 是一个轻量的 **Vue 3** [subconverter](https://github.com/tindy2013/
 
 ### 方式一：Cloudflare Pages（推荐）
 
-> Pages 承载前端和运行时配置；订阅转换仍需要可公开访问的 SCE 或传统后端。
+> Pages 承载前端和运行时配置；订阅转换仍需要可公开访问的 SubConverter-Extended 或传统后端。
 
 **详细教程请参阅 → [DEPLOY_CLOUDFLARE.md](DEPLOY_CLOUDFLARE.md)**
 
@@ -120,7 +120,7 @@ window.config = {
     {
       name: 'Aethersailor 后端',
       url: 'https://api.asailor.org',
-      type: 'sce',
+      type: 'subconverter-extended',
     },
     {
       name: '肥羊增强型后端',

--- a/shared/runtime-config.js
+++ b/shared/runtime-config.js
@@ -81,8 +81,14 @@ function normalizeApiBackends(value, issues, { requireHttps = false } = {}) {
     if (!url) {
       return [];
     }
-    const type = ['auto', 'sce', 'legacy'].includes(item?.type) ? item.type : 'auto';
-    if (item?.type !== undefined && item.type !== type) {
+    const requestedType = item?.type;
+    const type =
+      requestedType === 'sce'
+        ? 'subconverter-extended'
+        : ['auto', 'subconverter-extended', 'legacy'].includes(requestedType)
+          ? requestedType
+          : 'auto';
+    if (requestedType !== undefined && !['auto', 'sce', 'subconverter-extended', 'legacy'].includes(requestedType)) {
       issues.push(`后端 ${String(item?.name || new URL(url).host)} 的 type 无效，已使用 auto`);
     }
     return [{ name: String(item?.name || new URL(url).host).trim(), url: url.replace(/\/+$/, ''), type }];

--- a/src/converter/backend.js
+++ b/src/converter/backend.js
@@ -1,12 +1,15 @@
 export const BACKEND_TYPES = Object.freeze({
   AUTO: 'auto',
-  SCE: 'sce',
+  SUBCONVERTER_EXTENDED: 'subconverter-extended',
   LEGACY: 'legacy',
   UNKNOWN: 'unknown',
 });
 
 export function normalizeBackendType(value) {
-  return value === BACKEND_TYPES.SCE || value === BACKEND_TYPES.LEGACY ? value : BACKEND_TYPES.AUTO;
+  if (value === BACKEND_TYPES.SUBCONVERTER_EXTENDED || value === 'sce') {
+    return BACKEND_TYPES.SUBCONVERTER_EXTENDED;
+  }
+  return value === BACKEND_TYPES.LEGACY ? value : BACKEND_TYPES.AUTO;
 }
 
 export function parseBackendIdentity(value) {
@@ -14,13 +17,13 @@ export function parseBackendIdentity(value) {
     .trim()
     .replace(/\s+/g, ' ')
     .slice(0, 240);
-  const sceMatch = raw.match(/^SubConverter-Extended\s+([^\s]+)\s+backend$/i);
-  if (sceMatch) {
-    const token = sceMatch[1];
+  const extendedMatch = raw.match(/^SubConverter-Extended\s+([^\s]+)\s+backend$/i);
+  if (extendedMatch) {
+    const token = extendedMatch[1];
     const stable = token.match(/^(v\d+\.\d+\.\d+)(?:-([0-9a-f]{7,40}))?$/i);
     const development = token.match(/^dev(?:-([0-9a-f]{7,40}))?$/i);
     return {
-      family: BACKEND_TYPES.SCE,
+      family: BACKEND_TYPES.SUBCONVERTER_EXTENDED,
       version: stable?.[1] || (development ? 'dev' : token),
       channel: stable ? 'stable' : development ? 'dev' : 'unknown',
       revision: stable?.[2] || development?.[1] || '',

--- a/src/converter/profiles.js
+++ b/src/converter/profiles.js
@@ -46,7 +46,11 @@ export const BOOLEAN_PARAMETER_OPTIONS = Object.freeze([
   { key: 'append_type', label: '追加节点类型', hint: '在节点名后追加协议类型' },
   { key: 'tfo', label: 'TCP Fast Open', hint: '启用 TCP Fast Open' },
   { key: 'udp', label: 'UDP', hint: '启用 UDP 转发' },
-  { key: 'list', label: '服务端展开节点', hint: 'SCE 默认使用远程资源；开启后由后端解析并展开节点' },
+  {
+    key: 'list',
+    label: '服务端展开节点',
+    hint: 'SubConverter-Extended 默认使用远程资源；开启后由后端解析并展开节点',
+  },
   { key: 'sort', label: '排序节点', hint: '按后端规则排序节点' },
   { key: 'sort_script', label: '使用排序脚本', hint: '排序开启时使用后端配置的排序脚本' },
   { key: 'script', label: 'Clash Script', hint: '生成 Clash Script 配置' },
@@ -85,7 +89,7 @@ export const LEGACY_TARGET_OPTIONS = Object.freeze([
   { value: 'singbox', text: 'Sing-box' },
 ]);
 
-const SCE_TARGET_NAMES = Object.freeze([
+const SUBCONVERTER_EXTENDED_TARGET_NAMES = Object.freeze([
   'auto',
   'clash',
   'clashr',
@@ -148,18 +152,18 @@ function expandTarget(name) {
 }
 
 export function getTargetOptions(backendType) {
-  if (backendType !== BACKEND_TYPES.SCE) {
+  if (backendType !== BACKEND_TYPES.SUBCONVERTER_EXTENDED) {
     return LEGACY_TARGET_OPTIONS;
   }
-  return SCE_TARGET_NAMES.flatMap(expandTarget);
+  return SUBCONVERTER_EXTENDED_TARGET_NAMES.flatMap(expandTarget);
 }
 
 export function baseTarget(target) {
   return String(target || '').split('&', 1)[0];
 }
 
-const SCE_UNSUPPORTED = new Set(['groups', 'ruleset', 'new_name']);
-const SCE_TARGET_CONSTRAINTS = Object.freeze({
+const SUBCONVERTER_EXTENDED_UNSUPPORTED = new Set(['groups', 'ruleset', 'new_name']);
+const SUBCONVERTER_EXTENDED_TARGET_CONSTRAINTS = Object.freeze({
   dev_id: ['quanx'],
   provider_headers: ['clash', 'stash'],
   provider_proxy_direct: ['clash', 'clashr'],
@@ -168,14 +172,14 @@ const SCE_TARGET_CONSTRAINTS = Object.freeze({
 });
 
 export function isParameterAvailable(name, backendType, target) {
-  if (backendType !== BACKEND_TYPES.SCE) {
+  if (backendType !== BACKEND_TYPES.SUBCONVERTER_EXTENDED) {
     return name !== 'provider_headers';
   }
-  if (SCE_UNSUPPORTED.has(name)) {
+  if (SUBCONVERTER_EXTENDED_UNSUPPORTED.has(name)) {
     return false;
   }
   const targetName = baseTarget(target);
-  const constraints = SCE_TARGET_CONSTRAINTS[name];
+  const constraints = SUBCONVERTER_EXTENDED_TARGET_CONSTRAINTS[name];
   return !constraints || constraints.includes(targetName);
 }
 

--- a/src/views/home/SubTable.vue
+++ b/src/views/home/SubTable.vue
@@ -27,10 +27,14 @@
       <span class="field-hint">每行一条，也支持使用 | 分隔多个链接或节点。</span>
     </div>
 
-    <section v-if="isSce" class="sce-source-overview" aria-label="SCE 专属订阅来源参数">
-      <div class="sce-source-overview-heading">
+    <section
+      v-if="isSubConverterExtended"
+      class="subconverter-extended-source-overview"
+      aria-label="SubConverter-Extended 专属订阅来源参数"
+    >
+      <div class="subconverter-extended-source-overview-heading">
         <div>
-          <span class="sce-only-badge">SCE 专属</span>
+          <span class="subconverter-extended-only-badge">SubConverter-Extended 专属</span>
           <h3>订阅链接前缀参数</h3>
         </div>
         <button type="button" class="secondary-button compact-button" @click="toggleSourceEditor">
@@ -38,38 +42,42 @@
         </button>
       </div>
       <p>SubWeb 会把下列参数放在每条订阅链接之前，并按当前目标客户端检查是否可用。</p>
-      <div class="sce-source-capabilities">
-        <div class="sce-source-capability">
+      <div class="subconverter-extended-source-capabilities">
+        <div class="subconverter-extended-source-capability">
           <code>tag:</code>
           <span>标记订阅来源，供远程资源和分组匹配使用</span>
           <small>Clash / ClashR、Surge、QuanX、Loon、Surfboard、Stash</small>
         </div>
-        <div class="sce-source-capability">
+        <div class="subconverter-extended-source-capability">
           <code>provider:</code>
           <span>指定生成的 Provider 或远程资源名称</span>
           <small>Clash / ClashR、Surge、QuanX、Loon、Surfboard、Stash</small>
         </div>
-        <div class="sce-source-capability">
+        <div class="subconverter-extended-source-capability">
           <code>interval:</code>
           <span>为单条远程订阅指定更新间隔</span>
           <small>Clash / ClashR、Surge、QuanX、Stash</small>
         </div>
-        <div class="sce-source-capability">
+        <div class="subconverter-extended-source-capability">
           <code>proxy_direct:</code>
           <span>控制 Provider 下载时直连或跟随代理设置</span>
           <small>仅 Clash / ClashR</small>
         </div>
       </div>
-      <div class="sce-syntax-example">
+      <div class="subconverter-extended-syntax-example">
         <span>示例</span>
         <code>provider:机场 A,interval:3600,proxy_direct:true,https://example.com/sub</code>
       </div>
     </section>
 
-    <section v-if="isSce && isShowSourceEditor" class="source-editor reveal-block" aria-label="SCE 来源参数">
+    <section
+      v-if="isSubConverterExtended && isShowSourceEditor"
+      class="source-editor reveal-block"
+      aria-label="SubConverter-Extended 来源参数"
+    >
       <div class="options-heading">
         <div>
-          <h3>SCE 来源参数</h3>
+          <h3>SubConverter-Extended 来源参数</h3>
           <span>按目标客户端限制可用字段；应用后会写回上方来源列表。</span>
         </div>
         <button type="button" class="text-button" @click="addSourceItem">添加来源</button>
@@ -264,8 +272,8 @@
       <div class="options-section">
         <div class="options-heading">
           <h3>节点重命名与自定义配置</h3>
-          <span v-if="!isSce">自定义分组和规则会编码为 URL-safe Base64</span>
-          <span v-else>SCE 使用远程配置提供自定义分组和规则</span>
+          <span v-if="!isSubConverterExtended">自定义分组和规则会编码为 URL-safe Base64</span>
+          <span v-else>SubConverter-Extended 使用远程配置提供自定义分组和规则</span>
         </div>
         <div class="advanced-inputs">
           <div class="field">
@@ -277,7 +285,7 @@
               placeholder="正则@替换，多个规则使用 ` 分隔"
             ></textarea>
           </div>
-          <div v-if="!isSce" class="field">
+          <div v-if="!isSubConverterExtended" class="field">
             <label for="groups">自定义代理组</label>
             <textarea
               id="groups"
@@ -286,11 +294,11 @@
               placeholder="custom_proxy_group=...，多个项目使用 @ 分隔"
             ></textarea>
           </div>
-          <div v-if="isSce" class="capability-notice">
-            SCE 固定使用 Mihomo 新字段；<code>groups</code> 和 <code>ruleset</code>
+          <div v-if="isSubConverterExtended" class="capability-notice">
+            SubConverter-Extended 固定使用 Mihomo 新字段；<code>groups</code> 和 <code>ruleset</code>
             请求参数不会生效。请通过上方「远程配置」提供分组和规则。
           </div>
-          <div v-if="!isSce" class="field">
+          <div v-if="!isSubConverterExtended" class="field">
             <label for="ruleset">自定义规则集</label>
             <textarea
               id="ruleset"
@@ -356,16 +364,16 @@
       </button>
     </div>
 
-    <div v-if="isSce" class="diagnostic-actions">
+    <div v-if="isSubConverterExtended" class="diagnostic-actions">
       <button class="secondary-button" type="button" :disabled="diagnostics.loading" @click="runDiagnostics">
         <span v-if="diagnostics.loading" class="spinner" aria-hidden="true"></span>
-        {{ diagnostics.loading ? '正在诊断' : '让 SCE 诊断本次转换' }}
+        {{ diagnostics.loading ? '正在诊断' : '让 SubConverter-Extended 诊断本次转换' }}
       </button>
-      <span class="field-hint">诊断会立即把来源发送到当前 SCE 后端，但不会上传或生成短链接。</span>
+      <span class="field-hint"> 诊断会立即把来源发送到当前 SubConverter-Extended 后端，但不会上传或生成短链接。 </span>
     </div>
 
     <section v-if="diagnostics.payload || diagnostics.error" class="diagnostic-panel reveal-block" aria-live="polite">
-      <h3>SCE 诊断结果</h3>
+      <h3>SubConverter-Extended 诊断结果</h3>
       <p v-if="diagnostics.error" class="diagnostic-error">{{ diagnostics.error }}</p>
       <template v-else>
         <p>{{ diagnosticSummary }}</p>
@@ -439,7 +447,7 @@ export default {
       isShowRemoteConfig: false,
       isShowSourceEditor: false,
       sourceItems: [],
-      sceSourceModifiersApplied: false,
+      extendedSourceModifiersApplied: false,
       result: {
         subUrl: '',
         shortUrl: '',
@@ -464,7 +472,7 @@ export default {
       backendProbeRequestId: 0,
       lastTargetByBackend: {
         legacy: 'clash',
-        sce: 'clash',
+        'subconverter-extended': 'clash',
       },
       diagnostics: {
         loading: false,
@@ -484,10 +492,12 @@ export default {
       return countSuppressedOptions(this.moreConfig, this.backendType, this.target);
     },
     backendType() {
-      return this.backendProbe.type === BACKEND_TYPES.SCE ? BACKEND_TYPES.SCE : BACKEND_TYPES.LEGACY;
+      return this.backendProbe.type === BACKEND_TYPES.SUBCONVERTER_EXTENDED
+        ? BACKEND_TYPES.SUBCONVERTER_EXTENDED
+        : BACKEND_TYPES.LEGACY;
     },
-    isSce() {
-      return this.backendType === BACKEND_TYPES.SCE;
+    isSubConverterExtended() {
+      return this.backendType === BACKEND_TYPES.SUBCONVERTER_EXTENDED;
     },
     targetOptions() {
       return getTargetOptions(this.backendType);
@@ -503,8 +513,8 @@ export default {
         return '正在探测后端';
       }
       if (this.backendProbe.state === 'online') {
-        if (this.backendProbe.type === BACKEND_TYPES.SCE) {
-          return `在线 · SCE · ${this.backendProbe.version} · 已启用专用适配`;
+        if (this.backendProbe.type === BACKEND_TYPES.SUBCONVERTER_EXTENDED) {
+          return `在线 · SubConverter-Extended · ${this.backendProbe.version} · 已启用专用适配`;
         }
         if (this.backendProbe.type === BACKEND_TYPES.LEGACY) {
           return `在线 · 传统后端 · ${this.backendProbe.version}`;
@@ -512,8 +522,8 @@ export default {
         return `在线 · 后端类型未确认 · ${this.backendProbe.version}`;
       }
       if (this.backendProbe.state === 'unreachable') {
-        if (this.backendProbe.type === BACKEND_TYPES.SCE) {
-          return '浏览器无法验证后端；按站点配置使用 SCE 内置能力';
+        if (this.backendProbe.type === BACKEND_TYPES.SUBCONVERTER_EXTENDED) {
+          return '浏览器无法验证后端；按站点配置使用 SubConverter-Extended 内置能力';
         }
         if (this.backendProbe.type === BACKEND_TYPES.LEGACY) {
           return '浏览器无法验证后端；按站点配置使用传统模式';
@@ -653,7 +663,9 @@ export default {
         const resolvedType = resolveBackendType(configuredType, identity.family, true);
         let warning = '';
         if (resolvedType === BACKEND_TYPES.UNKNOWN && configuredType !== BACKEND_TYPES.AUTO) {
-          warning = `站点把后端配置为 ${configuredType === BACKEND_TYPES.SCE ? 'SCE' : '传统模式'}，但 /version 返回了不同类型；已暂停专用能力。`;
+          warning = `站点把后端配置为 ${
+            configuredType === BACKEND_TYPES.SUBCONVERTER_EXTENDED ? 'SubConverter-Extended' : '传统模式'
+          }，但 /version 返回了不同类型；已暂停专用能力。`;
         }
         if (requestId !== this.backendProbeRequestId) return;
         this.setBackendProbe({
@@ -676,7 +688,9 @@ export default {
           warning:
             fallbackType === BACKEND_TYPES.UNKNOWN
               ? ''
-              : `未能验证后端身份，暂按站点配置使用${fallbackType === BACKEND_TYPES.SCE ? ' SCE 内置能力' : '传统模式'}。`,
+              : `未能验证后端身份，暂按站点配置使用${
+                  fallbackType === BACKEND_TYPES.SUBCONVERTER_EXTENDED ? ' SubConverter-Extended 内置能力' : '传统模式'
+                }。`,
         });
       } finally {
         window.clearTimeout(timeoutId);
@@ -720,7 +734,7 @@ export default {
         this.isShowSourceEditor = false;
         this.sourceItems = [];
       }
-      this.sceSourceModifiersApplied = false;
+      this.extendedSourceModifiersApplied = false;
       this.diagnostics = { loading: false, payload: null, error: '' };
     },
     toggleSourceEditor() {
@@ -743,7 +757,7 @@ export default {
     applySourceItems() {
       try {
         this.urls = serializeSceSourceItems(this.sourceItems, this.target);
-        this.sceSourceModifiersApplied = this.sourceItems.some((item) =>
+        this.extendedSourceModifiersApplied = this.sourceItems.some((item) =>
           ['tag', 'provider', 'interval', 'proxyDirect'].some((key) => String(item[key] || '').trim()),
         );
         this.isShowSourceEditor = false;
@@ -795,10 +809,10 @@ export default {
     getConverter() {
       this.clearFormMessage();
       this.result = { subUrl: '', shortUrl: '' };
-      if (this.isSce && this.isShowSourceEditor) {
+      if (this.isSubConverterExtended && this.isShowSourceEditor) {
         try {
           this.urls = serializeSceSourceItems(this.sourceItems, this.target);
-          this.sceSourceModifiersApplied = this.sourceItems.some((item) =>
+          this.extendedSourceModifiersApplied = this.sourceItems.some((item) =>
             ['tag', 'provider', 'interval', 'proxyDirect'].some((key) => String(item[key] || '').trim()),
           );
         } catch (error) {
@@ -810,11 +824,14 @@ export default {
         this.setFormMessage('请输入订阅链接或节点。', 'urls');
         return false;
       }
-      if (!this.isSce && this.sceSourceModifiersApplied) {
-        this.setFormMessage('来源包含由 SCE 编辑器生成的专用参数。请切回 SCE，或手工清除这些前缀。', 'urls');
+      if (!this.isSubConverterExtended && this.extendedSourceModifiersApplied) {
+        this.setFormMessage(
+          '来源包含由 SubConverter-Extended 编辑器生成的专用参数。请切回 SubConverter-Extended，或手工清除这些前缀。',
+          'urls',
+        );
         return false;
       }
-      if (this.isSce) {
+      if (this.isSubConverterExtended) {
         try {
           validateSourceItems(parseSourceItems(this.urls), this.target);
         } catch (error) {
@@ -859,7 +876,7 @@ export default {
       }
     },
     async runDiagnostics() {
-      if (!window.confirm('诊断会立即把当前来源发送到所选 SCE 后端。确认继续吗？')) {
+      if (!window.confirm('诊断会立即把当前来源发送到所选 SubConverter-Extended 后端。确认继续吗？')) {
         return;
       }
       if (!this.getConverter()) return;
@@ -1281,7 +1298,7 @@ select {
   color: var(--danger);
 }
 
-.sce-source-overview {
+.subconverter-extended-source-overview {
   display: grid;
   gap: 14px;
   padding: 18px;
@@ -1290,36 +1307,36 @@ select {
   border-radius: 22px;
 }
 
-.sce-source-overview-heading {
+.subconverter-extended-source-overview-heading {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
 }
 
-.sce-source-overview-heading > div {
+.subconverter-extended-source-overview-heading > div {
   display: flex;
   align-items: center;
   gap: 10px;
 }
 
-.sce-source-overview h3,
-.sce-source-overview p {
+.subconverter-extended-source-overview h3,
+.subconverter-extended-source-overview p {
   margin: 0;
 }
 
-.sce-source-overview h3 {
+.subconverter-extended-source-overview h3 {
   color: var(--text-primary);
   font-size: 0.96rem;
 }
 
-.sce-source-overview p {
+.subconverter-extended-source-overview p {
   color: var(--text-muted);
   font-size: 0.8rem;
   line-height: 1.55;
 }
 
-.sce-only-badge {
+.subconverter-extended-only-badge {
   padding: 5px 8px;
   color: var(--accent-blue);
   font-size: 0.7rem;
@@ -1330,13 +1347,13 @@ select {
   border-radius: 999px;
 }
 
-.sce-source-capabilities {
+.subconverter-extended-source-capabilities {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 10px;
 }
 
-.sce-source-capability {
+.subconverter-extended-source-capability {
   display: grid;
   min-width: 0;
   gap: 5px;
@@ -1346,8 +1363,8 @@ select {
   border-radius: 14px;
 }
 
-.sce-source-capability code,
-.sce-syntax-example code,
+.subconverter-extended-source-capability code,
+.subconverter-extended-syntax-example code,
 .source-syntax-preview code {
   color: var(--accent-blue);
   font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
@@ -1355,19 +1372,19 @@ select {
   font-weight: 800;
 }
 
-.sce-source-capability span {
+.subconverter-extended-source-capability span {
   color: var(--text-secondary);
   font-size: 0.78rem;
   line-height: 1.45;
 }
 
-.sce-source-capability small {
+.subconverter-extended-source-capability small {
   color: var(--text-muted);
   font-size: 0.68rem;
   line-height: 1.4;
 }
 
-.sce-syntax-example,
+.subconverter-extended-syntax-example,
 .source-syntax-preview {
   display: grid;
   gap: 6px;
@@ -1377,14 +1394,14 @@ select {
   border-radius: 12px;
 }
 
-.sce-syntax-example span,
+.subconverter-extended-syntax-example span,
 .source-syntax-preview span {
   color: var(--text-muted);
   font-size: 0.68rem;
   font-weight: 700;
 }
 
-.sce-syntax-example code,
+.subconverter-extended-syntax-example code,
 .source-syntax-preview code {
   overflow-wrap: anywhere;
   white-space: normal;
@@ -1630,17 +1647,17 @@ select {
     grid-template-columns: 1fr;
   }
 
-  .sce-source-overview-heading,
+  .subconverter-extended-source-overview-heading,
   .diagnostic-actions {
     align-items: flex-start;
     flex-direction: column;
   }
 
-  .sce-source-overview-heading .secondary-button {
+  .subconverter-extended-source-overview-heading .secondary-button {
     width: 100%;
   }
 
-  .sce-source-capabilities {
+  .subconverter-extended-source-capabilities {
     grid-template-columns: 1fr;
   }
 

--- a/src/views/home/index.js
+++ b/src/views/home/index.js
@@ -95,7 +95,11 @@ export function getSubLink({ urls, api, target, remoteConfig = '', moreConfig = 
   }
 
   const effectiveConfig = filterMoreConfig(moreConfig, backendType, target);
-  if (backendType === 'sce' && effectiveConfig.script === 'true' && effectiveConfig.expand === 'true') {
+  if (
+    backendType === 'subconverter-extended' &&
+    effectiveConfig.script === 'true' &&
+    effectiveConfig.expand === 'true'
+  ) {
     throw new TypeError('Clash Script 与内联展开规则集不能同时开启');
   }
 

--- a/test/backend-identity.test.js
+++ b/test/backend-identity.test.js
@@ -2,9 +2,9 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { BACKEND_TYPES, parseBackendIdentity, resolveBackendType } from '../src/converter/backend.js';
 
-test('识别 SCE 正式版、开发版和传统后端版本', () => {
+test('识别 SubConverter-Extended 正式版、开发版和传统后端版本', () => {
   assert.deepEqual(parseBackendIdentity('SubConverter-Extended v1.9.2-483a9e7 backend'), {
-    family: 'sce',
+    family: 'subconverter-extended',
     version: 'v1.9.2',
     channel: 'stable',
     revision: '483a9e7',
@@ -16,9 +16,18 @@ test('识别 SCE 正式版、开发版和传统后端版本', () => {
 });
 
 test('后端配置与在线身份冲突时进入未知安全模式', () => {
-  assert.equal(resolveBackendType('auto', BACKEND_TYPES.SCE, true), BACKEND_TYPES.SCE);
-  assert.equal(resolveBackendType('sce', BACKEND_TYPES.SCE, true), BACKEND_TYPES.SCE);
-  assert.equal(resolveBackendType('sce', BACKEND_TYPES.LEGACY, true), BACKEND_TYPES.UNKNOWN);
-  assert.equal(resolveBackendType('sce', BACKEND_TYPES.UNKNOWN, false), BACKEND_TYPES.SCE);
+  assert.equal(
+    resolveBackendType('auto', BACKEND_TYPES.SUBCONVERTER_EXTENDED, true),
+    BACKEND_TYPES.SUBCONVERTER_EXTENDED,
+  );
+  assert.equal(
+    resolveBackendType('subconverter-extended', BACKEND_TYPES.SUBCONVERTER_EXTENDED, true),
+    BACKEND_TYPES.SUBCONVERTER_EXTENDED,
+  );
+  assert.equal(resolveBackendType('subconverter-extended', BACKEND_TYPES.LEGACY, true), BACKEND_TYPES.UNKNOWN);
+  assert.equal(
+    resolveBackendType('subconverter-extended', BACKEND_TYPES.UNKNOWN, false),
+    BACKEND_TYPES.SUBCONVERTER_EXTENDED,
+  );
   assert.equal(resolveBackendType('auto', BACKEND_TYPES.UNKNOWN, false), BACKEND_TYPES.UNKNOWN);
 });

--- a/test/backend-profiles.test.js
+++ b/test/backend-profiles.test.js
@@ -3,9 +3,9 @@ import test from 'node:test';
 import { countSuppressedOptions, getTargetOptions, isParameterAvailable } from '../src/converter/profiles.js';
 import { getSubLink } from '../src/views/home/index.js';
 
-test('SCE 内置目标完整且传统目标保持原列表', () => {
-  const sce = getTargetOptions('sce');
-  assert.equal(sce.length, 25);
+test('SubConverter-Extended 内置目标完整且传统目标保持原列表', () => {
+  const extendedTargets = getTargetOptions('subconverter-extended');
+  assert.equal(extendedTargets.length, 25);
   for (const target of [
     'auto',
     'stash',
@@ -18,7 +18,7 @@ test('SCE 内置目标完整且传统目标保持原列表', () => {
     'mixed',
   ]) {
     assert.ok(
-      sce.some((item) => item.value === target),
+      extendedTargets.some((item) => item.value === target),
       `缺少 ${target}`,
     );
   }
@@ -30,24 +30,24 @@ test('SCE 内置目标完整且传统目标保持原列表', () => {
   );
 });
 
-test('SCE 参数按目标限制，传统模式保持历史可用性', () => {
-  assert.equal(isParameterAvailable('groups', 'sce', 'clash'), false);
-  assert.equal(isParameterAvailable('new_name', 'sce', 'clash'), false);
-  assert.equal(isParameterAvailable('provider_proxy_direct', 'sce', 'clash'), true);
-  assert.equal(isParameterAvailable('provider_proxy_direct', 'sce', 'stash'), false);
-  assert.equal(isParameterAvailable('provider_headers', 'sce', 'stash'), true);
-  assert.equal(isParameterAvailable('provider_headers', 'sce', 'surge&ver=4'), false);
+test('SubConverter-Extended 参数按目标限制，传统模式保持历史可用性', () => {
+  assert.equal(isParameterAvailable('groups', 'subconverter-extended', 'clash'), false);
+  assert.equal(isParameterAvailable('new_name', 'subconverter-extended', 'clash'), false);
+  assert.equal(isParameterAvailable('provider_proxy_direct', 'subconverter-extended', 'clash'), true);
+  assert.equal(isParameterAvailable('provider_proxy_direct', 'subconverter-extended', 'stash'), false);
+  assert.equal(isParameterAvailable('provider_headers', 'subconverter-extended', 'stash'), true);
+  assert.equal(isParameterAvailable('provider_headers', 'subconverter-extended', 'surge&ver=4'), false);
   assert.equal(isParameterAvailable('groups', 'legacy', 'clash'), true);
   assert.equal(isParameterAvailable('provider_headers', 'legacy', 'clash'), false);
 });
 
-test('SCE 链接不发送被忽略或强制的参数', () => {
+test('SubConverter-Extended 链接不发送被忽略或强制的参数', () => {
   const link = new URL(
     getSubLink({
       urls: 'ss://node',
       api: 'https://api.example.com',
       target: 'clash',
-      backendType: 'sce',
+      backendType: 'subconverter-extended',
       moreConfig: {
         groups: 'ignored group',
         ruleset: 'ignored rule',
@@ -62,17 +62,20 @@ test('SCE 链接不发送被忽略或强制的参数', () => {
   assert.equal(link.searchParams.has('new_name'), false);
   assert.equal(link.searchParams.get('provider_proxy_direct'), 'true');
   assert.equal(link.searchParams.get('provider_headers'), 'X-Test-Key');
-  assert.equal(countSuppressedOptions({ groups: 'x', provider_proxy_direct: 'true' }, 'sce', 'stash'), 2);
+  assert.equal(
+    countSuppressedOptions({ groups: 'x', provider_proxy_direct: 'true' }, 'subconverter-extended', 'stash'),
+    2,
+  );
 });
 
-test('SCE 拒绝同时开启 Clash Script 和内联规则', () => {
+test('SubConverter-Extended 拒绝同时开启 Clash Script 和内联规则', () => {
   assert.throws(
     () =>
       getSubLink({
         urls: 'ss://node',
         api: 'https://api.example.com',
         target: 'clash',
-        backendType: 'sce',
+        backendType: 'subconverter-extended',
         moreConfig: { script: 'true', expand: 'true' },
       }),
     /不能同时开启/,

--- a/test/cloudflare-config.test.js
+++ b/test/cloudflare-config.test.js
@@ -42,15 +42,15 @@ test('Pages Function 保留后端类型、拒绝不安全后端并限制请求�
     request: new Request('https://sub.example.com/conf/config.js'),
     env: {
       API_BACKENDS: JSON.stringify([
-        { name: 'SCE', url: 'https://api.example.com', type: 'sce' },
+        { name: 'SubConverter-Extended', url: 'https://api.example.com', type: 'subconverter-extended' },
         { name: '传统', url: 'https://legacy.example.com', type: 'legacy' },
-        { name: '不安全', url: 'http://plain.example.com', type: 'sce' },
+        { name: '不安全', url: 'http://plain.example.com', type: 'subconverter-extended' },
       ]),
     },
   });
   const config = parseConfigScript(await response.text());
   assert.deepEqual(config.apiBackends, [
-    { name: 'SCE', url: 'https://api.example.com', type: 'sce' },
+    { name: 'SubConverter-Extended', url: 'https://api.example.com', type: 'subconverter-extended' },
     { name: '传统', url: 'https://legacy.example.com', type: 'legacy' },
   ]);
 

--- a/test/runtime-config.test.js
+++ b/test/runtime-config.test.js
@@ -48,13 +48,19 @@ test('后端类型保持向后兼容并规范化无效值', () => {
   const { config, issues } = normalizeRuntimeConfig({
     ...DEFAULT_RUNTIME_CONFIG,
     apiBackends: [
-      { name: 'SCE', url: 'https://sce.example.com', type: 'sce' },
+      { name: 'SubConverter-Extended', url: 'https://extended.example.com', type: 'subconverter-extended' },
+      { name: '旧简称配置', url: 'https://alias.example.com', type: 'sce' },
       { name: '旧配置', url: 'https://legacy.example.com' },
       { name: '错误类型', url: 'https://unknown.example.com', type: 'extended' },
     ],
   });
   assert.deepEqual(config.apiBackends, [
-    { name: 'SCE', url: 'https://sce.example.com', type: 'sce' },
+    {
+      name: 'SubConverter-Extended',
+      url: 'https://extended.example.com',
+      type: 'subconverter-extended',
+    },
+    { name: '旧简称配置', url: 'https://alias.example.com', type: 'subconverter-extended' },
     { name: '旧配置', url: 'https://legacy.example.com', type: 'auto' },
     { name: '错误类型', url: 'https://unknown.example.com', type: 'auto' },
   ]);

--- a/test/source-modifiers.test.js
+++ b/test/source-modifiers.test.js
@@ -7,7 +7,7 @@ import {
   validateSourceItems,
 } from '../src/converter/source-modifiers.js';
 
-test('解析并规范化 SCE 来源前缀', () => {
+test('解析并规范化 SubConverter-Extended 来源前缀', () => {
   assert.deepEqual(parseSourceItem('tag:香港,provider:机场,interval:3600,proxy_direct:false,https://example.com/sub'), {
     url: 'https://example.com/sub',
     tag: '香港',


### PR DESCRIPTION
## Summary

- replace the conversational abbreviation with the full `SubConverter-Extended` project name across the UI, documentation, internal identifiers, CSS classes, and test descriptions
- change the canonical backend type to `subconverter-extended`
- continue accepting the former short type value as an input-only compatibility alias while always normalizing output to `subconverter-extended`

## Validation

- `npm run check`: formatting, ESLint, 28 Node.js tests, Vite production build, Pages Functions bundle
- repository search confirms no user-visible abbreviated project name remains