### PR TITLE
fix(ui): avoid repeated backend name in status

### DIFF
--- a/src/views/home/SubTable.vue
+++ b/src/views/home/SubTable.vue
@@ -514,7 +514,7 @@ export default {
       }
       if (this.backendProbe.state === 'online') {
         if (this.backendProbe.type === BACKEND_TYPES.SUBCONVERTER_EXTENDED) {
-          return `在线 · SubConverter-Extended · ${this.backendProbe.version} · 已启用专用适配`;
+          return `在线 · ${this.backendProbe.version} · 已启用专用适配`;
         }
         if (this.backendProbe.type === BACKEND_TYPES.LEGACY) {
           return `在线 · 传统后端 · ${this.backendProbe.version}`;


### PR DESCRIPTION
## Summary

- avoid repeating the full SubConverter-Extended project name in the online status text
- retain the full backend-provided version string as the single project-name occurrence

## Validation

- `npm run check`: formatting, ESLint, 28 Node.js tests, Vite build, Pages Functions bundle